### PR TITLE
Allow installing on older Python versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -127,5 +127,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.10"
-content-hash = "74695ce568dd8ae66974fe8b2c54dd1b2282852c36fdcc6f7fa5bab39ff919c4"
+python-versions = ">=3.8"
+content-hash = "1c773722dc12e67202607be822ae0113fa4fa6b79123d8efa83e50fc0adb6309"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ readme = "README.rst"
 repository = "https://github.com/jackrosenthal/legacy-cgi"
 
 [tool.poetry.dependencies]
-python = ">=3.10"
+python = ">=3.8"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.1"


### PR DESCRIPTION
Update the minimal required python version to 3.8. This will allow projects to support a wider range of Python versions.